### PR TITLE
Update parse-exif to use images directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # product
 
+This repository contains assets for the **3D Home Configure Module & Catalog**.
+

--- a/src/parse-exif.js
+++ b/src/parse-exif.js
@@ -4,13 +4,14 @@ const path = require('path');
 const { parse } = require('./simple-exif-parser');
 
 const rootDir = path.resolve(__dirname, '..');
+const imagesDir = path.join(rootDir, 'products', 'images');
 const output = path.join(rootDir, 'metadata.json');
 
-const files = fs.readdirSync(rootDir);
+const files = fs.readdirSync(imagesDir);
 const images = files.filter(f => /\.(jpg|jpeg|png|webp)$/i.test(f));
 const data = [];
 for (const file of images) {
-  const filePath = path.join(rootDir, file);
+  const filePath = path.join(imagesDir, file);
   const buffer = fs.readFileSync(filePath);
   const exif = parse(buffer);
   data.push({ file, exif });


### PR DESCRIPTION
## Summary
- parse images from `products/images` instead of repository root
- document 3D Home Configure Module & Catalog in README

## Testing
- `node tests/test.js`
- `python3 tests/test_readme.py`
